### PR TITLE
Updates the docker-api gem requirement.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'docker-api', '~> 1.15.0'
+gem 'docker-api', '~> 1.21.4'
 
 group(:development, :test) do
   gem 'rspec', '~> 3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    archive-tar-minitar (0.5.2)
     diff-lcs (1.2.5)
-    docker-api (1.15.0)
-      archive-tar-minitar
+    docker-api (1.21.4)
       excon (>= 0.38.0)
       json
-    excon (0.41.0)
-    json (1.8.1)
+    excon (0.45.3)
+    json (1.8.3)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -26,5 +24,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  docker-api (~> 1.15.0)
+  docker-api (~> 1.21.4)
   rspec (~> 3.1.0)

--- a/tainers.gemspec
+++ b/tainers.gemspec
@@ -11,10 +11,10 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.files       = Dir.glob('lib/**/*.rb') + Dir.glob('spec/**/*.rb') + Dir.glob('bin/*') + Dir.glob('Gemfile*')
-  
+
   s.executables << 'tainers'
 
-  s.add_dependency('docker-api', '~> 1.15.0')
+  s.add_dependency('docker-api', '~> 1.21.4')
 
   s.add_development_dependency('bundler', '~> 1.7.6')
   s.add_development_dependency('rspec', '~> 3.1.0')


### PR DESCRIPTION
As of 1.19.0 the docker-api gem supports the docker registry 2 API.
For good measure I have updated to the latest version of the gem (1.21.4)